### PR TITLE
Build coffeescript files before publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ npm-debug.log
 .#*
 
 .DS_Store
+/build

--- a/index.js
+++ b/index.js
@@ -1,2 +1,1 @@
-require('coffee-script/register')
-module.exports = require('./lib')
+module.exports = require('./build')

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Handlebars helper for smart partials import.",
   "main": "index.js",
   "scripts": {
+    "prepare": "coffee -o build -c lib",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -17,8 +18,10 @@
   },
   "homepage": "https://github.com/resin-io-playground/doxx-handlebars-helper",
   "dependencies": {
-    "coffee-script": "^1.10.0",
     "handlebars": "^4.0.5",
     "lodash": "^4.11.1"
+  },
+  "devDependencies": {
+    "coffeescript": "^1.12.7"
   }
 }


### PR DESCRIPTION
This avoids the needs to compile on every run

Change-type: patch